### PR TITLE
use a read-only connection to catalogue db

### DIFF
--- a/cads_catalogue_api_service/client.py
+++ b/cads_catalogue_api_service/client.py
@@ -434,7 +434,7 @@ class CatalogueClient(stac_fastapi.types.core.BaseCoreClient):
     @property
     def reader(self) -> sqlalchemy.orm.Session:
         """Return the reader session on the catalogue database."""
-        session_maker = dependencies.get_sessionmaker()
+        session_maker = dependencies.get_sessionmaker(read_only=True)
         return session_maker
 
     def _landing_page(

--- a/cads_catalogue_api_service/config.py
+++ b/cads_catalogue_api_service/config.py
@@ -40,6 +40,11 @@ class SqlalchemySettings(stac_fastapi.types.config.ApiSettings):  # type: ignore
         """Create reader psql connection string."""
         return cads_catalogue.config.ensure_settings().connection_string
 
+    @property
+    def connection_string_read(self) -> str:
+        """Create reader psql connection string."""
+        return cads_catalogue.config.ensure_settings().connection_string_read
+
 
 class Settings(pydantic.BaseSettings):
     """Other general settings.

--- a/cads_catalogue_api_service/dependencies.py
+++ b/cads_catalogue_api_service/dependencies.py
@@ -24,15 +24,23 @@ from . import config, fastapisessionmaker
 
 
 @functools.lru_cache()
-def get_sessionmaker() -> fastapisessionmaker.FastAPISessionMaker:
+def get_sessionmaker(read_only=True) -> fastapisessionmaker.FastAPISessionMaker:
     """Generate a DB session using fastapi_utils."""
-    connection_string = config.dbsettings.connection_string
+    if read_only:
+        connection_string = config.dbsettings.connection_string_read
+    else:
+        connection_string = config.dbsettings.connection_string
     return fastapisessionmaker.FastAPISessionMaker(connection_string)
 
 
 def get_session() -> Iterator[sqlalchemy.orm.Session]:
-    """Fastapi dependency that provides a sqlalchemy session."""
-    yield from get_sessionmaker().get_db()
+    """Fastapi dependency that provides a sqlalchemy read-only session."""
+    yield from get_sessionmaker(read_only=True).get_db()
+
+
+def get_session_rw() -> Iterator[sqlalchemy.orm.Session]:
+    """Fastapi dependency that provides a sqlalchemy read&write session."""
+    yield from get_sessionmaker(read_only=False).get_db()
 
 
 def get_portals_values(portal: str) -> list[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,11 @@ import pytest
 def temp_environ() -> Any:
     """Create a modifiable environment that affect only the test scope."""
     old_environ = dict(os.environ)
+    os.environ["CATALOGUE_DB_HOST"] = "dbhost"
+    os.environ["CATALOGUE_DB_HOST_READ"] = "dbhostread"
+    os.environ["CATALOGUE_DB_USER"] = "dbuser"
     os.environ["CATALOGUE_DB_PASSWORD"] = "password"
+    os.environ["CATALOGUE_DB_NAME"] = "dbname"
 
     yield
 

--- a/tests/test_10_settings.py
+++ b/tests/test_10_settings.py
@@ -19,10 +19,12 @@ import cads_catalogue_api_service.config
 
 def test_sqlsettings_env() -> None:
     """Test that the default SQL settings can be taken from env vars."""
-    os.environ["CATALOGUE_DB_NAME"] = "bar"
+    os.environ["CATALOGUE_DB_HOST"] = "host1"
+    os.environ["CATALOGUE_DB_HOST_READ"] = "host2"
     settings = cads_catalogue_api_service.config.SqlalchemySettings()
 
-    assert "/bar" in settings.connection_string
+    assert "host1" in settings.connection_string
+    assert "host2" in settings.connection_string_read
 
 
 def test_settings_env() -> None:


### PR DESCRIPTION
According to https://jira.ecmwf.int/browse/COPDS-1323 : 
 * client must use a read-only connection to the catalogue db (supported eventually by db replicas)
 * in the code a r/w connection is supported
