### PR TITLE
COPDS-2439: sorting on contents

### DIFF
--- a/cads_catalogue_api_service/contents.py
+++ b/cads_catalogue_api_service/contents.py
@@ -20,7 +20,7 @@ import cads_catalogue
 import fastapi
 import sqlalchemy as sa
 
-from . import config, dependencies, models
+from . import config, dependencies, extensions, models
 
 router = fastapi.APIRouter(
     prefix="/contents",
@@ -37,10 +37,20 @@ def _apply_common_filters(query, site: str, ctype: str | None = None):
     )
 
 
+def get_sorting_clause(sort: str) -> tuple:
+    supported_sorts = {
+        "title": (cads_catalogue.database.Content.title, sa.asc),
+        "publication": (cads_catalogue.database.Content.publication_date, sa.desc),
+        "update": (cads_catalogue.database.Content.content_update, sa.desc),
+    }
+    return supported_sorts.get(sort) or supported_sorts["title"]
+
+
 def query_contents(
     session: sa.orm.Session,
     site: str,
     ctype: str | None = None,
+    sortby: str = "title",
 ):
     """Perform a database query for multiple contents, ideally filtereb by type."""
     stmt_count = _apply_common_filters(
@@ -55,9 +65,15 @@ def query_contents(
             detail=f"Content type {ctype} not implemented",
         )
 
+    # Get secondary sorting clause
+    sort_by, sort_order_fn = get_sorting_clause(sortby)
+
     stmt_query = _apply_common_filters(
         sa.select(cads_catalogue.database.Content), site, ctype
-    ).order_by(cads_catalogue.database.Content.title)
+    ).order_by(
+        sa.desc(cads_catalogue.database.Content.priority), sort_order_fn(sort_by)
+    )
+
     results = session.scalars(stmt_query).all()
     return count, results
 
@@ -166,11 +182,12 @@ def _build_contents_response(results, request: fastapi.Request):
 )
 def list_contents(
     request: fastapi.Request,
+    sortby: extensions.ContentSortCriterion = extensions.ContentSortCriterion.title_asc,
     session=fastapi.Depends(dependencies.get_session),
     site=fastapi.Depends(dependencies.get_site),
 ) -> models.contents.Contents:
     """Endpoint to get all contents in the material catalogue."""
-    count, results = query_contents(session, site=site)
+    count, results = query_contents(session, site=site, sortby=sortby)
 
     return models.contents.Contents(
         count=count,
@@ -190,11 +207,12 @@ def list_contents(
 def list_contents_of_type(
     request: fastapi.Request,
     ctype: str,
+    sortby: extensions.ContentSortCriterion = extensions.ContentSortCriterion.title_asc,
     session=fastapi.Depends(dependencies.get_session),
     site=fastapi.Depends(dependencies.get_site),
 ) -> models.contents.Contents:
     """Endpoint to get all contents of a single type in the material catalogue."""
-    count, results = query_contents(session, site=site, ctype=ctype)
+    count, results = query_contents(session, site=site, ctype=ctype, sortby=sortby)
 
     return models.contents.Contents(
         count=count,

--- a/cads_catalogue_api_service/extensions.py
+++ b/cads_catalogue_api_service/extensions.py
@@ -33,6 +33,12 @@ class CatalogueSortCriterion(str, enum.Enum):
     id_asc = "id"
 
 
+class ContentSortCriterion(str, enum.Enum):
+    title_asc = "title"
+    publication_desc = "publication"
+    update_desc = "update"
+
+
 def datasets_search(
     request: fastapi.Request,
     q: str = fastapi.Query(default=None, description="Full-text search query"),

--- a/tests/test_40_contents.py
+++ b/tests/test_40_contents.py
@@ -74,6 +74,7 @@ def static_query_contents(
     session: Any,
     site: str,
     ctype: str | None = None,
+    sortby: str | None = None,
 ):
     results = (
         STATIC_RESULTS


### PR DESCRIPTION
`/api/catalogue/v1/contents/`:
- default hidden sort by `priority`
- secondary sort by `title_asc` (default), `publication_desc`, `update_desc`

[COPDS-2439](https://jira.ecmwf.int/browse/COPDS-2439)