### PR TITLE
chore: added the "unknown" status for sanity_check

### DIFF
--- a/cads_catalogue_api_service/sanity_check.py
+++ b/cads_catalogue_api_service/sanity_check.py
@@ -15,6 +15,7 @@ class SanityCheckStatus(str, Enum):
     available = "available"
     warning = "warning"
     down = "down"
+    unknown = "unknown"
 
 
 class SanityCheckOutput(BaseModel):
@@ -90,15 +91,16 @@ def process(
 
     Calculates the status based on the following rules:
 
-    1. If sanity_check is None or empty or has more than 3 tests, status is "available".
-    2. For 1 test:
+    1. If sanity_check is None or empty, status is "unknown".
+    2. If sanity_check has more than 3 checks, only last 3 checks are taken into account.
+    3. For 1 checks:
        - If successful, status is "available"
        - If failed, status is "down"
-    3. For 2 tests:
+    3. For 2 checks:
        - If 2 tests succeeded, status is "available"
        - If 1 test succeeded, status is "warning"
        - If 0 tests succeeded, status is "down"
-    4. For 3 tests:
+    4. For 3 checks:
        - If 3 or 2 tests succeeded, status is "available"
        - If 1 test succeeded, status is "warning"
        - If 0 tests succeeded, status is "down"
@@ -109,12 +111,12 @@ def process(
 
     Returns
     -------
-        Dict with "status" ("available", "warning", or "down") and
-        "timestamp" (from the first test if available)
+        When sanity_check data is available, a dict with "status" ("available", "warning",
+        "down" or "unknown") and "timestamp" (from the first check, if available)
     """
     # Default status for empty checks
     if not sanity_check:
-        return SanityCheckResult(status=SanityCheckStatus.available, timestamp=None)
+        return SanityCheckResult(status=SanityCheckStatus.unknown, timestamp=None)
 
     # Just take into account latest X tests (tests are sorted descending by finished_at)
     sanity_check = sanity_check[:SANITY_CHECK_MAX_ENTRIES]

--- a/cads_catalogue_api_service/sanity_check.py
+++ b/cads_catalogue_api_service/sanity_check.py
@@ -111,8 +111,8 @@ def process(
 
     Returns
     -------
-        When sanity_check data is available, a dict with "status" ("available", "warning",
-        "down" or "unknown") and "timestamp" (from the first check, if available)
+        A dict with "status" ("available", "warning", "down" or "unknown") and "timestamp"
+        (from the first check, if available)
     """
     # Default status for empty checks
     if not sanity_check:

--- a/schemas/dataset_preview.json
+++ b/schemas/dataset_preview.json
@@ -62,8 +62,8 @@
         "status": {
           "type": "string",
           "title": "Status",
-          "description": "The status of the sanity check",
-          "enum": ["available", "warning", "down"]
+          "description": "The result of the sanity check on the dataset",
+          "enum": ["available", "warning", "down", "unknown"]
         },
         "timestamp": {
           "type": "string",

--- a/tests/test_60_sanity_check.py
+++ b/tests/test_60_sanity_check.py
@@ -90,11 +90,11 @@ def test_process() -> None:
 
     # Test case: None or empty list
     assert process(None) == SanityCheckResult(
-        status=SanityCheckStatus.available,
+        status=SanityCheckStatus.unknown,
         timestamp=None,
     )
     assert process([]) == SanityCheckResult(
-        status=SanityCheckStatus.available,
+        status=SanityCheckStatus.unknown,
         timestamp=None,
     )
 


### PR DESCRIPTION
In this way we can signal datasets where we don't have any sanity_check information